### PR TITLE
enable full compatibility with react 0.12.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,20 @@
 var jshintLoader = require("jshint-loader");
-var jsxLoader = require("jsx-loader");
+var reactTools = require('react-tools');
+var loaderUtils = require('loader-utils');
 
-module.exports = function(input) {
-  jshintLoader.call(
-    this,
-    jsxLoader.call(this, input)
-  );
-  return input;
+module.exports = function(source) {
+  this.cacheable && this.cacheable();
+
+  var query = loaderUtils.parseQuery(this.query);
+  if (query.insertPragma) {
+    source = '/** @jsx ' + query.insertPragma + ' */' + source;
+  }
+  var transform = reactTools.transformWithDetails(source, {
+    harmony: query.harmony,
+    es5: query.es5
+  });
+
+  // all the query information were only meant for the jsx-compiler
+  this.query = '';
+  jshintLoader.call(this,transform.code);
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     }
   ],
   "dependencies": {
-    "jsx-loader": "~0.10.2",
-    "jshint-loader": "~0.6.0"
+    "jshint-loader": "~0.8.0",
+    "react-tools": "^0.12.0",
+    "loader-utils": "^0.2.2"
   }
 }


### PR DESCRIPTION
I’ve avoided using the jsx-loader since version 0.12.0 calls webpack's `this.callback` just like jshint-loader leading to a conflict.
Instead I’m using the react tools directly to transform the source.
